### PR TITLE
Add Windows optimization flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,12 +121,15 @@ class build_ext(distutils.command.build_ext.build_ext):
 # compilation flags for C extensions
 #==============================================================================
 compile_flags, cpplib = ['-std=c++11', '-Wall', '-Wno-deprecated'],  ['stdc++']
+link_flags = []
 if platform.system() == 'Darwin':
     compile_flags += ['--stdlib=libc++']
     cpplib = ['c++']
 elif platform.system() == 'Windows':
-    compile_flags = ['-DNBUILD', '-DNLGLYALSAT' , '/DINCREMENTAL', '-DNLGLOG',
-            '-DNDEBUG', '-DNCHKSOL', '-DNLGLFILES', '-DNLGLDEMA', '-I./win']
+    compile_flags = ['-O2', '-DNBUILD', '-DNLGLYALSAT', '/DINCREMENTAL',
+            '-DNLGLOG', '-DNDEBUG', '-DNCHKSOL', '-DNLGLFILES', '-DNLGLDEMA',
+            '-I./win']
+    link_flags = ['-O2']
     cpplib = []
 
 
@@ -135,6 +138,7 @@ elif platform.system() == 'Windows':
 pycard_ext = Extension('pycard',
     sources=['cardenc/pycard.cc'],
     extra_compile_args=compile_flags,
+    extra_link_args=link_flags,
     include_dirs=['cardenc'] ,
     language='c++',
     libraries=cpplib,
@@ -162,6 +166,7 @@ pysolvers_ext = Extension('pysolvers',
     sources=pysolvers_sources,
     extra_compile_args=compile_flags + \
         list(map(lambda x: '-DWITH_{0}'.format(x.upper()), to_install)),
+    extra_link_args=link_flags,
     include_dirs=['solvers'],
     language='c++',
     libraries=libraries,


### PR DESCRIPTION
## Summary
- ensure Windows builds use `-O2` for compilation and linking
- hook link optimization flags into `pycard` and `pysolvers` extension modules

## Testing
- `PYTHONPATH=build/lib.linux-x86_64-cpython-312 pytest tests/test_cnf.py` *(fails: ModuleNotFoundError: No module named 'pysolvers')*


------
https://chatgpt.com/codex/tasks/task_e_6893439a3a588322afada658c80a6df3