### PR TITLE
Add optimization flags across platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,13 +121,20 @@ class build_ext(distutils.command.build_ext.build_ext):
 # compilation flags for C extensions
 #==============================================================================
 compile_flags, cpplib = ['-std=c++11', '-Wall', '-Wno-deprecated'],  ['stdc++']
+link_flags = []
 if platform.system() == 'Darwin':
-    compile_flags += ['--stdlib=libc++']
+    compile_flags += ['--stdlib=libc++', '-O3', '-flto']
+    link_flags += ['-O3', '-flto']
     cpplib = ['c++']
 elif platform.system() == 'Windows':
-    compile_flags = ['-DNBUILD', '-DNLGLYALSAT' , '/DINCREMENTAL', '-DNLGLOG',
-            '-DNDEBUG', '-DNCHKSOL', '-DNLGLFILES', '-DNLGLDEMA', '-I./win']
+    compile_flags = ['-O2', '-flto', '-DNBUILD', '-DNLGLYALSAT', '/DINCREMENTAL',
+            '-DNLGLOG', '-DNDEBUG', '-DNCHKSOL', '-DNLGLFILES', '-DNLGLDEMA',
+            '-I./win']
+    link_flags = ['-O2', '-flto']
     cpplib = []
+else:
+    compile_flags += ['-O3', '-flto']
+    link_flags += ['-O3', '-flto']
 
 
 # C extensions: pycard and pysolvers
@@ -135,6 +142,7 @@ elif platform.system() == 'Windows':
 pycard_ext = Extension('pycard',
     sources=['cardenc/pycard.cc'],
     extra_compile_args=compile_flags,
+    extra_link_args=link_flags,
     include_dirs=['cardenc'] ,
     language='c++',
     libraries=cpplib,
@@ -162,6 +170,7 @@ pysolvers_ext = Extension('pysolvers',
     sources=pysolvers_sources,
     extra_compile_args=compile_flags + \
         list(map(lambda x: '-DWITH_{0}'.format(x.upper()), to_install)),
+    extra_link_args=link_flags,
     include_dirs=['solvers'],
     language='c++',
     libraries=libraries,

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ except ImportError:
 import distutils.command.build
 import distutils.command.build_ext
 import distutils.command.install
+import distutils.ccompiler
 
 import inspect, os, sys
 sys.path.insert(0, os.path.join(os.path.realpath(os.path.abspath(os.path.split(inspect.getfile(inspect.currentframe()))[0])), 'solvers/'))
@@ -127,10 +128,17 @@ if platform.system() == 'Darwin':
     link_flags += ['-O3', '-flto']
     cpplib = ['c++']
 elif platform.system() == 'Windows':
-    compile_flags = ['-O2', '-flto', '-DNBUILD', '-DNLGLYALSAT', '/DINCREMENTAL',
+    compiler = distutils.ccompiler.get_default_compiler()
+    compile_flags = ['-DNBUILD', '-DNLGLYALSAT', '/DINCREMENTAL',
             '-DNLGLOG', '-DNDEBUG', '-DNCHKSOL', '-DNLGLFILES', '-DNLGLDEMA',
             '-I./win']
-    link_flags = ['-O2', '-flto']
+    link_flags = []
+    if compiler == 'msvc':
+        compile_flags += ['/O2', '/GL']
+        link_flags += ['/LTCG']
+    else:
+        compile_flags += ['-O2', '-flto']
+        link_flags += ['-O2', '-flto']
     cpplib = []
 else:
     compile_flags += ['-O3', '-flto']


### PR DESCRIPTION
## Summary
- ensure Windows builds use `-O2` and `-flto` for compilation and linking
- enable `-O3` and `-flto` for compile and link on Unix builds to leverage link-time optimization

## Testing
- `python setup.py build` *(fails: /usr/bin/ld: cannot find -lmaplesat: No such file or directory)*
- `PYTHONPATH=build/lib.linux-x86_64-cpython-312 pytest tests/test_cnf.py` *(fails: ModuleNotFoundError: No module named 'pysolvers')*


------
https://chatgpt.com/codex/tasks/task_e_6893439a3a588322afada658c80a6df3